### PR TITLE
Добавил команду sync в фазу скачивания пакетов 1С

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add bash curl grep \
   && chmod +x /download.sh \
-  && /download.sh \
+  && sync; /download.sh \
   && for file in *.tar.gz; do tar -zxf "$file"; done \
   && rm -rf *.tar.gz
 

--- a/crs/Dockerfile
+++ b/crs/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add bash curl grep \
   && chmod +x /download.sh \
-  && /download.sh \
+  && sync; /download.sh \
   && for file in *.tar.gz; do tar -zxf "$file"; done \
   && rm -rf *.tar.gz
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add bash curl grep \
   && chmod +x /download.sh \
-  && /download.sh \
+  && sync; /download.sh \
   && for file in *.tar.gz; do tar -zxf "$file"; done \
   && rm -rf *.tar.gz
 

--- a/server/Dockerfile.i386
+++ b/server/Dockerfile.i386
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add bash curl grep \
   && chmod +x /download.sh \
-  && /download.sh \
+  && sync; /download.sh \
   && for file in *.tar.gz; do tar -zxf "$file"; done \
   && rm -rf *.tar.gz
 

--- a/thin-client/Dockerfile
+++ b/thin-client/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 
 RUN apk --no-cache add bash curl grep \
   && chmod +x /download.sh \
-  && /download.sh \
+  && sync; /download.sh \
   && for file in *.tar.gz; do tar -zxf "$file"; done \
   && rm -rf *.tar.gz
 


### PR DESCRIPTION
https://github.com/moby/moby/issues/9547

На Ubuntu 16.04 с драйвером `aufs` словил данный баг:

`Text file busy`

Добавил каоманду `sync` после `chmod +x` в качестве воркэраунда, как и советуют в вышеописанном ишу.